### PR TITLE
Rename tokens

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Dispatch repo
       uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
       with:
-        token: ${{ secrets.ADMIN_TOKEN }}
+        token: ${{secrets.REPO_CONTENT_WRITE_TOKEN}}
         repository: ${{ github.repository_owner }}/access-ram-condaenv
         event-type: release
         client-payload: |-

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -86,5 +86,5 @@ jobs:
           {
             "dependency": "${{needs.get-package-name.outputs.package-name}}",
             "version": "${{github.ref_name}}",
-            "token": "${{secrets.ADMIN_TOKEN}}"
+            "token": "${{secrets.NO_PERMISSIONS_TOKEN}}"
           }

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -86,5 +86,5 @@ jobs:
           {
             "dependency": "${{needs.get-package-name.outputs.package-name}}",
             "version": "${{github.ref_name}}",
-            "token": "${{secrets.NO_PERMISSIONS_TOKEN}}"
+            "token": "${{secrets.REPO_DISPATCH_VERIFICATION_TOKEN}}"
           }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Dispatch repo
       uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
       with:
-        token: ${{ secrets.ADMIN_TOKEN }}
+        token: ${{secrets.REPO_CONTENT_WRITE_TOKEN}}
         repository: ${{ github.repository_owner }}/access-ram-condaenv
         event-type: prerelease
         client-payload: |-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,5 +92,5 @@ jobs:
         event-type: prerelease
         client-payload: |-
           {
-            "token": "${{secrets.NO_PERMISSIONS_TOKEN}}"
+            "token": "${{secrets.REPO_DISPATCH_VERIFICATION_TOKEN}}"
           }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,5 +92,5 @@ jobs:
         event-type: prerelease
         client-payload: |-
           {
-            "token": "${{secrets.ADMIN_TOKEN}}"
+            "token": "${{secrets.NO_PERMISSIONS_TOKEN}}"
           }


### PR DESCRIPTION
Small PR to change names of tokens used in the worklows for a better differentiation of purposes/permissions.

All the tokens have been created using the `access-bot` user and added to this repo as secrets.